### PR TITLE
Correct Typo in Class Names for Consistency

### DIFF
--- a/lib/ui/result_page.dart
+++ b/lib/ui/result_page.dart
@@ -49,7 +49,7 @@ class _ResultBodyState extends State<_ResultBody> {
         Padding(
           padding: const EdgeInsets.symmetric(vertical: 16.0),
           // todo-03: show the inference result (food name and the confidence score)
-          child: ClassificatioinItem(item: "Nasi Lemak", value: "89.58%"),
+          child: ClassificationItem(item: "Nasi Lemak", value: "89.58%"),
         ),
       ],
     );

--- a/lib/widget/classification_item.dart
+++ b/lib/widget/classification_item.dart
@@ -25,8 +25,8 @@ class ClassificationItem extends StatelessWidget {
   }
 }
 
-class ClassificatioinItemShimmer extends StatelessWidget {
-  const ClassificatioinItemShimmer({super.key});
+class ClassificationItemShimmer extends StatelessWidget {
+  const ClassificationItemShimmer({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widget/classification_item.dart
+++ b/lib/widget/classification_item.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 
-class ClassificatioinItem extends StatelessWidget {
+class ClassificationItem extends StatelessWidget {
   final String item;
   final String value;
 
-  const ClassificatioinItem({
+  const ClassificationItem({
     super.key,
     required this.item,
     required this.value,


### PR DESCRIPTION
This pull request addresses typographical errors in class names by renaming:

- ClassificatioinItemShimmer to ClassificationItemShimmer
- ClassificatioinItem to ClassificationItem
